### PR TITLE
Fix `typing.Set`

### DIFF
--- a/unicodedata_reader/entry.py
+++ b/unicodedata_reader/entry.py
@@ -10,7 +10,6 @@ from typing import Iterable
 from typing import List
 from typing import Optional
 from typing import Sequence
-from typing import Set
 from typing import Union
 from typing import Tuple
 
@@ -273,20 +272,20 @@ class UnicodeDataEntries(object):
         """Returns an `Iterable` of Unicode code points for the given `pred`."""
         return itertools.chain(*(e.range() for e in self.filter(pred)))
 
-    def add_to_set(self, pred: Callable[[Any], bool], set: Set[int]) -> None:
+    def add_to_set(self, pred: Callable[[Any], bool], set: set) -> None:
         """Add values `pred` returns `True` to `set[int]`."""
         for code in self.codes_for(pred):
             set.add(code)
 
     def remove_from_set(self, pred: Callable[[Any], bool],
-                        set: Set[int]) -> None:
+                        set: set) -> None:
         """Remove values `pred` returns `True` from `set[int]`."""
         for code in self.codes_for(pred):
             set.discard(code)
 
-    def to_set(self, pred: Callable[[Any], bool]) -> Set[int]:
+    def to_set(self, pred: Callable[[Any], bool]) -> set:
         """Returns a `set[int]` of values `pred` returns `True`."""
-        s = set()  # type: set[int]
+        s = set()
         self.add_to_set(pred, s)
         return s
 

--- a/unicodedata_reader/set.py
+++ b/unicodedata_reader/set.py
@@ -1,7 +1,7 @@
 from typing import Any
 from typing import Callable
 from typing import Iterable
-from typing import Set
+from typing import Optional
 
 from unicodedata_reader.entry import *
 from unicodedata_reader.reader import *
@@ -11,9 +11,9 @@ class Set(object):
     """A simple wrapper of a `set` of Unicode code points."""
 
     def __init__(self,
-                 entries: UnicodeDataEntries = None,
-                 pred: Callable[[Any], bool] = None) -> None:
-        self.set = set()  # type: Set[int]
+                 entries: Optional[UnicodeDataEntries] = None,
+                 pred: Optional[Callable[[Any], bool]] = None) -> None:
+        self.set = set()
         if entries:
             self.add_entries(entries, pred)
 


### PR DESCRIPTION
[`typing.Set`](https://docs.python.org/3/library/typing.html#typing.Set) is deprecated since 3.9, but 3.8 doesn't support subscripting.

Using `set` instead of `Set[int]` and `set[int]` looks reasonable until 3.8 is deprecated.