### PR TITLE
Remove `reader` from arguments of `Set` static methods

### DIFF
--- a/unicodedata_reader/entry.py
+++ b/unicodedata_reader/entry.py
@@ -277,8 +277,7 @@ class UnicodeDataEntries(object):
         for code in self.codes_for(pred):
             set.add(code)
 
-    def remove_from_set(self, pred: Callable[[Any], bool],
-                        set: set) -> None:
+    def remove_from_set(self, pred: Callable[[Any], bool], set: set) -> None:
         """Remove values `pred` returns `True` from `set[int]`."""
         for code in self.codes_for(pred):
             set.discard(code)

--- a/unicodedata_reader/set.py
+++ b/unicodedata_reader/set.py
@@ -46,25 +46,21 @@ class Set(object):
         entries.add_to_set(pred, self.set)
 
     @staticmethod
-    def east_asian_width(
-            value: str,
-            reader: UnicodeDataReader = UnicodeDataReader.default) -> 'Set':
+    def east_asian_width(value: str) -> 'Set':
+        reader = UnicodeDataReader.default
         return Set(reader.east_asian_width(), lambda v: v == value)
 
     @staticmethod
-    def general_category(
-            value: str,
-            reader: UnicodeDataReader = UnicodeDataReader.default) -> 'Set':
+    def general_category(value: str) -> 'Set':
+        reader = UnicodeDataReader.default
         return Set(reader.general_category(), lambda v: v.startswith(value))
 
     @staticmethod
-    def scripts(
-            value: str,
-            reader: UnicodeDataReader = UnicodeDataReader.default) -> 'Set':
+    def scripts(value: str) -> 'Set':
+        reader = UnicodeDataReader.default
         return Set(reader.scripts(), lambda v: v == value)
 
     @staticmethod
-    def script_extensions(
-            value: str,
-            reader: UnicodeDataReader = UnicodeDataReader.default) -> 'Set':
+    def script_extensions(value: str) -> 'Set':
+        reader = UnicodeDataReader.default
         return Set(reader.script_extensions(), lambda v: value in v)


### PR DESCRIPTION
In preparation for supporting variable non-keyword arguments.

`UnicodeDataReader.Context` can be used to change the reader.