### PR TITLE
Revert "Use `setuptools-scm`"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# setuptools-scm
-src/unicodedata_reader/_version.py
-
 .vscode/
 
 # Byte-compiled / optimized / DLL files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [project]
 name = "unicodedata-reader"
-# version = "1.3.6"
-dynamic = ["version"]
+version = "1.3.6"
 description = ""
 authors = [{name = "Koji Ishii", email="kojii@chromium.org"}]
 readme = "README.md"
@@ -28,8 +27,8 @@ dev = [
 unicodedata-reader = 'unicodedata_reader.__main__:main'
 
 [build-system]
-requires = ["setuptools>=80", "setuptools-scm>=8"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [tool.ruff.lint]
 ignore = [
@@ -39,13 +38,6 @@ ignore = [
 
 [tool.pytest.ini_options]
 testpaths = "tests"
-
-[tool.setuptools_scm]
-version_file = "src/unicodedata_reader/_version.py"
-
-[tool.uv]
-# https://docs.astral.sh/uv/concepts/cache/#dynamic-metadata
-cache-keys = [{ file = "pyproject.toml" }, { git = { commit = true, tags = true } }]
 
 [tool.yapf]
 based_on_style = "pep8"

--- a/src/unicodedata_reader/__init__.py
+++ b/src/unicodedata_reader/__init__.py
@@ -1,8 +1,3 @@
-try:
-    from ._version import version as __version__  # type: ignore
-except ImportError:
-    __version__ = "0.0.0+unknown"
-
 from .entry import *
 from .reader import *
 from .compressor import *

--- a/src/unicodedata_reader/cli.py
+++ b/src/unicodedata_reader/cli.py
@@ -11,7 +11,6 @@ from typing import Optional
 import unicodedata
 
 from unicodedata_reader import *
-from unicodedata_reader import __version__
 
 
 def _to_unicodes_from_str(text):
@@ -139,10 +138,6 @@ class UnicodeDataCli(object):
                             help='increase output verbosity',
                             action='count',
                             default=0)
-        parser.add_argument("-V",
-                            "--version",
-                            action="version",
-                            version=f"%(prog)s {__version__}")
         parser.parse_args(namespace=self)
         _init_logging(self.verbose)  # pytype: disable=attribute-error
         if self.clear_cache:

--- a/src/unicodedata_reader/compressor.py
+++ b/src/unicodedata_reader/compressor.py
@@ -8,7 +8,6 @@ import sys
 from typing import Optional
 
 from unicodedata_reader import *
-from unicodedata_reader import __version__
 
 _logger = logging.getLogger('UnicodeDataCompressor')
 
@@ -120,10 +119,6 @@ def main():
                         help='increase output verbosity',
                         action='count',
                         default=0)
-    parser.add_argument("-V",
-                        "--version",
-                        action="version",
-                        version=f"%(prog)s {__version__}")
     args = parser.parse_args()
     _init_logging(args.verbose)
 


### PR DESCRIPTION
This patch reverts PR #184 because dependabot doesn't work.

See https://github.com/kojiishi/east_asian_spacing/issues/298.
